### PR TITLE
공용으로 사용될 카드 컴포넌트 생성

### DIFF
--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+// material-ui
+import { Stack, StackProps } from '@mui/material';
+
+interface CardProps {
+  sx?: StackProps['sx'];
+  width?: number;
+  height?: number;
+  children: React.ReactNode
+}
+export const Card = ({children, sx, width, height}: CardProps) => (
+    <Stack boxShadow={3} borderRadius={5} padding={4} sx={{ ...sx, width: width && `${width}px`, height: height && `${height}px` }}>
+      {children}
+    </Stack>
+)
+
+

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -1,0 +1,1 @@
+export * from './Card'


### PR DESCRIPTION
## 요약

- 공용으로 사용될 카드 컴포넌트 생성

## 상세

- 해당 컴포넌트는 아래와 같이 사용이 가능합니다.

1. Card 컴포넌트 import
 - import { Card } from 'components/common'
2. Card 프로퍼티 종류
- 자세한 프로퍼티는 해당 컴포넌트를 들어가서 확인할 수 있습니다.
- 1) width : width를 number 형태로 넣으시면 됩니다. `<Card width={120} />` 
- 2) height : height를 number 형태로 넣으시면 됩니다. `<Card height={120} />`  
- 3) sx : sx는 mui의 style을 나타냅니다. sx를 사용하기 위해서는 다음과 같이 카멜케이스를 사용해야 합니다. `<Card sx={{ borderRadius: '20px', minHeight: '300px' }} />`


이 컴포넌트는 기본적으로 padding : 32px, boxShadow, borderRadius: 20px 이 적용되어있습니다. 해당 옵션은 공통 옵션이니 수정은 불가합니다.